### PR TITLE
Add support for git-style symlinks

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -672,7 +672,7 @@ packages:
     source: hosted
     version: "3.2.1"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   org_flutter: ^10.3.1
   # org_flutter:
     # path: ../org_flutter
+  path: ^1.8.0
   path_provider: ^2.0.9
   share_plus: ^12.0.0
   shared_preferences: ^2.0.0


### PR DESCRIPTION
Transclusion wasn't working for paths like [[file:img/achilles.jpg]] where img is a symlink managed by GitHub (stored as a text file containing the target path).

This adds a fallback in resolveRelative that walks path components individually and follows these portable symlink files when encountered.